### PR TITLE
Update "Unoffical DevRant Api Docs" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ devRant is a fun community for developers to connect over code, tech & life as a
 ### Links
 
 - [Official Website](https://devrant.com)
-- [Unofficial API Docs](https://devrant-docs.github.io)
+- [Unofficial API Docs](https://devrantapi.docs.apiary.io)
 - [devRant Official Issue Tracker](https://github.com/devRant/devRant)
 
 ### Social


### PR DESCRIPTION
The old url is no longer working and new url can be found in [this thread/rant](https://devrant.com/collabs/2644989/unofficial-devrant-api-documentation-remake-of-the-old-devrant-docs-site).